### PR TITLE
feat: start game running on load

### DIFF
--- a/lifegame/src/app.js
+++ b/lifegame/src/app.js
@@ -215,5 +215,6 @@
   cellSizeVal.textContent = String(cellSize);
   resizeCanvas();
   randomize(0.2);
+  toggleRunning();
 })();
 


### PR DESCRIPTION
## Summary
- start simulation automatically by toggling running state during initialization

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` stub script verifying start button label becomes "⏸ 停止"


------
https://chatgpt.com/codex/tasks/task_e_689766fad43083249f40cba6c998ada1