### PR TITLE
feat: orient lifegame grid vertically by default

### DIFF
--- a/lifegame/README.md
+++ b/lifegame/README.md
@@ -16,7 +16,7 @@
 - `Makefile`: Convenience `serve` target using Python’s `http.server`.
 
 ## Notes
-- Default grid is 80×50, with toroidal wrapping ON.
+- Default grid is 50×80, with toroidal wrapping ON.
 - Adjust cell size and FPS live; resizing resets the grid for simplicity.
 - Rendering uses Canvas with light grid lines and green live cells.
 

--- a/lifegame/index.html
+++ b/lifegame/index.html
@@ -17,8 +17,8 @@
         <label>速度 <input id="speed" type="range" min="1" max="60" value="10" /> <span id="speedVal">10</span>fps</label>
         <label>セル <input id="cellSize" type="range" min="4" max="20" value="10" /> <span id="cellSizeVal">10</span>px</label>
         <label>トーラス <input id="wrap" type="checkbox" checked /></label>
-        <label>列 <input id="cols" type="number" min="10" max="300" value="80" /></label>
-        <label>行 <input id="rows" type="number" min="10" max="200" value="50" /></label>
+        <label>列 <input id="cols" type="number" min="10" max="300" value="50" /></label>
+        <label>行 <input id="rows" type="number" min="10" max="200" value="80" /></label>
         <button id="resize">↔︎ リサイズ</button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- make default grid dimensions vertical (50 columns × 80 rows) so it displays better on phones
- update README to reflect new default grid orientation

## Testing
- `make serve`
- `make stop`


------
https://chatgpt.com/codex/tasks/task_e_68976853882883248eac1e60631f0609